### PR TITLE
Add `plot_revenue_by_category` diagram function and test script

### DIFF
--- a/src/diagrams.py
+++ b/src/diagrams.py
@@ -1,0 +1,22 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def plot_revenue_by_category(df: pd.DataFrame):
+    """
+    Stapeldiagram: intäkt per kategori.
+    Använder kolumner 'category' och 'revenue'.
+    """
+    grouped = (
+        df.groupby("category", as_index=False)["revenue"]
+        .sum()
+        .sort_values("revenue", ascending=False)
+    )
+
+    plt.figure()
+    plt.bar(grouped["category"], grouped["revenue"])
+    plt.xlabel("Kategori")
+    plt.ylabel("Intäkt (revenue)")
+    plt.title("Intäkt per kategori")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()

--- a/src/diagrams.py
+++ b/src/diagrams.py
@@ -20,3 +20,24 @@ def plot_revenue_by_category(df: pd.DataFrame):
     plt.title("Intäkt per kategori")
     plt.xticks(rotation=45, ha="right")
     plt.tight_layout()
+    
+    
+def plot_revenue_by_city(df: pd.DataFrame):
+    """
+    Stapeldiagram: intäkt per stad.
+    Använder kolumnerna 'city' och 'revenue'.
+    """
+    grouped = (
+        df.groupby("city", as_index=False)["revenue"]
+        .sum()
+        .sort_values("revenue", ascending=False)
+    )
+
+    plt.figure()
+    plt.bar(grouped["city"], grouped["revenue"])
+    plt.xlabel("Stad")
+    plt.ylabel("Intäkt (revenue)")
+    plt.title("Intäkt per stad")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+

--- a/src/diagrams.py
+++ b/src/diagrams.py
@@ -41,3 +41,36 @@ def plot_revenue_by_city(df: pd.DataFrame):
     plt.xticks(rotation=45, ha="right")
     plt.tight_layout()
 
+
+def plot_revenue_over_time(df: pd.DataFrame, freq: str = "M"):
+    """
+    Linjediagram: intäkt över tid.
+    
+    freq:
+        'D' = per dag
+        'W' = per vecka
+        'M' = per månad (standard)
+    Använder kolumnerna 'date' och 'revenue'.
+    """
+    df_copy = df.copy()
+
+    # Gör om date till datetime
+    df_copy["date"] = pd.to_datetime(df_copy["date"])
+
+    # Gruppera och summera intäkter per tidsenhet
+    grouped = (
+        df_copy
+        .set_index("date")
+        .groupby(pd.Grouper(freq=freq))["revenue"]
+        .sum()
+        .reset_index()
+        .sort_values("date")
+    )
+
+    plt.figure()
+    plt.plot(grouped["date"], grouped["revenue"], marker="o")
+    plt.xlabel("Datum")
+    plt.ylabel("Intäkt (revenue)")
+    plt.title(f"Intäkt över tid (freq={freq})")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()

--- a/tests/test_diagrams.py
+++ b/tests/test_diagrams.py
@@ -9,7 +9,8 @@ sys.path.append(PROJECT_ROOT)
 
 from src.diagrams import (
     plot_revenue_by_category,
-    plot_revenue_by_city
+    plot_revenue_by_city,
+    plot_revenue_over_time
 )
 
 
@@ -36,6 +37,18 @@ def main():
     print("==============================\n")
 
     plot_revenue_by_city(df)
+    plt.show()
+
+    input("\nTryck Enter för att fortsätta till nästa test...")
+
+    # =====================================================
+    # TEST 3 – intäkt över tid per månad
+    # =====================================================
+    print("\n==============================")
+    print("TEST 3: plot_revenue_over_time (per månad)")
+    print("==============================\n")
+
+    plot_revenue_over_time(df, freq="ME")
     plt.show()
 
     input("\nTryck Enter för att avsluta...")

--- a/tests/test_diagrams.py
+++ b/tests/test_diagrams.py
@@ -7,20 +7,38 @@ CURRENT_DIR = os.path.dirname(__file__)
 PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT_DIR, ".."))
 sys.path.append(PROJECT_ROOT)
 
-from src.diagrams import plot_revenue_by_category
+from src.diagrams import (
+    plot_revenue_by_category,
+    plot_revenue_by_city
+)
 
 
 def main():
-    # Ladda datan
     df = pd.read_csv("data/ecommerce_sales.csv")
 
-    # Testa funktionen
-    plot_revenue_by_category(df)
+    # =====================================================
+    # TEST 1 – intäkt per kategori
+    # =====================================================
+    print("\n==============================")
+    print("TEST 1: plot_revenue_by_category")
+    print("==============================\n")
 
-    # Visa diagrammet
+    plot_revenue_by_category(df)
     plt.show()
 
-    input("Tryck Enter för att avsluta...")
+    input("\nTryck Enter för att fortsätta till nästa test...")
+
+    # =====================================================
+    # TEST 2 – intäkt per stad
+    # =====================================================
+    print("\n==============================")
+    print("TEST 2: plot_revenue_by_city")
+    print("==============================\n")
+
+    plot_revenue_by_city(df)
+    plt.show()
+
+    input("\nTryck Enter för att avsluta...")
 
 
 if __name__ == "__main__":

--- a/tests/test_diagrams.py
+++ b/tests/test_diagrams.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+
+CURRENT_DIR = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT_DIR, ".."))
+sys.path.append(PROJECT_ROOT)
+
+from src.diagrams import plot_revenue_by_category
+
+
+def main():
+    # Ladda datan
+    df = pd.read_csv("data/ecommerce_sales.csv")
+
+    # Testa funktionen
+    plot_revenue_by_category(df)
+
+    # Visa diagrammet
+    plt.show()
+
+    input("Tryck Enter för att avsluta...")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Lagt till filen src/diagrams.py
- Lagt till första diagramfunktionen plot_revenue_by_category
<img width="349" height="208" alt="Skärmbild på diagram" src="https://github.com/user-attachments/assets/1bbc9414-b4d3-4101-b78c-e28aa7719636" />

- Lagt till andra diagramfunktionen plot_revenue_by_city
<img width="348" height="208" alt="diagram intäkt per stad" src="https://github.com/user-attachments/assets/4d6c24fe-9f18-4c41-9f2d-a258be656845" />


- Lagt till tredje diagramfunktionen plot_revenue_over_time
<img width="347" height="216" alt="diagram intäkt över tid" src="https://github.com/user-attachments/assets/aa9506b2-a8dc-48ab-8eb9-688db01dc3ef" />

- Skapat enkel testfil i tests/

För att testa, kör följande i terminalen efter att ha aktiverat virtuella miljön: 
`python tests/test_diagrams.py`


